### PR TITLE
Fix missing null check on terrainToTileNether

### DIFF
--- a/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
@@ -141,6 +141,7 @@ public class TerrainTiling {
         WorldTerrainSummary terrain = WorldSummary.of(world).terrain();
         if (terrain == null) return null;
         ChunkSummary chunk = terrain.get(pos);
+        if (chunk == null) return null; // Skip events fired for chunks we don't have yet (e.g. new shares)
         @Nullable LayerSummary.Raw lowSummary = chunk.toSingleLayer(null, NETHER_SCAN_HEIGHT, world.getTopY());
         @Nullable LayerSummary.Raw fullSummary = chunk.toSingleLayer(null, world.getBottomY() + world.getDimension().logicalHeight() - 1, world.getTopY());
         IndexedIterable<Biome> biomePalette = terrain.getBiomePalette(pos);


### PR DESCRIPTION
This missing check can cause crashes in [some cases](https://github.com/sisby-folk/antique-atlas/issues/143#issuecomment-2307150985). I just copied the null check from `terrainToTile` to `terrainToTileNether`.
