### PR TITLE
Require an item to open the map

### DIFF
--- a/src/main/java/folk/sisby/antique_atlas/AntiqueAtlas.java
+++ b/src/main/java/folk/sisby/antique_atlas/AntiqueAtlas.java
@@ -17,6 +17,9 @@ import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.item.ModelPredicateProviderRegistry;
 import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -64,6 +67,16 @@ public class AntiqueAtlas implements ClientModInitializer {
 
 	public static boolean isHandheldAtlas(ItemStack stack) {
 		return stack.isOf(Items.BOOK) && ATLAS_NAMES.stream().anyMatch(n -> stack.getName().getString().contains(n));
+	}
+
+	public static boolean hasHandheldAtlas(PlayerEntity player) {
+		if (isHandheldAtlas(player.getOffHandStack())) return true;
+		for (ItemStack itemStack : player.getInventory().main) {
+			if (isHandheldAtlas(itemStack)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/folk/sisby/antique_atlas/AntiqueAtlasConfig.java
+++ b/src/main/java/folk/sisby/antique_atlas/AntiqueAtlasConfig.java
@@ -26,6 +26,9 @@ public class AntiqueAtlasConfig extends WrappedConfig {
 	@Comment("The background is slightly less stylish, but more tiles are shown at once")
 	public boolean fullscreen = true;
 
+	@Comment("Whether to require an item to display the map")
+	public boolean requireItem = false;
+
 	@Comment("Whether to keep scale after closing the map")
 	public boolean keepZoom = false;
 

--- a/src/main/java/folk/sisby/antique_atlas/AntiqueAtlasKeybindings.java
+++ b/src/main/java/folk/sisby/antique_atlas/AntiqueAtlasKeybindings.java
@@ -18,12 +18,14 @@ public class AntiqueAtlasKeybindings {
 
 	public static void onClientTick(MinecraftClient client) {
 		while (ATLAS_KEYMAPPING.wasPressed()) {
-			if (client.currentScreen == null) {
-				AtlasScreen screen = new AtlasScreen();
-				screen.init();
-				screen.prepareToOpen();
-				screen.tick();
-				client.setScreen(screen);
+			if (!AntiqueAtlas.CONFIG.requireItem || AntiqueAtlas.hasHandheldAtlas(client.player)) {
+				if (client.currentScreen == null) {
+					AtlasScreen screen = new AtlasScreen();
+					screen.init();
+					screen.prepareToOpen();
+					screen.tick();
+					client.setScreen(screen);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds a new config option to require a Antique Atlas book in order to open the world map. This allows modpack developers to require an item without reintroducing the old Antique Atlas item. This config option defaults to `false` to retain existing behaviour.

Happy to port this to 1.21.1 as well if the feature is of interest!