### PR TITLE
make buttons easier to use in addons

### DIFF
--- a/src/main/java/folk/sisby/antique_atlas/gui/AtlasScreen.java
+++ b/src/main/java/folk/sisby/antique_atlas/gui/AtlasScreen.java
@@ -76,6 +76,8 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 	public boolean isDragging = false;
 	public final boolean fullscreen;
 
+	private int sideButtonY = 14;
+
 	public AtlasScreen() {
 		fullscreen = AntiqueAtlas.CONFIG.fullscreen;
 		if (fullscreen) {
@@ -99,7 +101,8 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 		});
 
 		addMarkerBookmark = new BookmarkButton(TEXT_ADD_MARKER, ICON_ADD_MARKER, DyeColor.RED.getFireworkColor(), null, 16, 16, false);
-		addChild(addMarkerBookmark).offsetGuiCoords(bookWidth - 10, 14);
+		addChild(addMarkerBookmark);
+		offsetSideButton(addMarkerBookmark);
 		addMarkerBookmark.addListener(button -> {
 			if (state.is(PLACING_MARKER)) {
 				selectedButton = null;
@@ -125,7 +128,8 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 			}
 		});
 		deleteMarkerBookmark = new BookmarkButton(Text.translatable("gui.antique_atlas.delMarker"), ICON_DELETE_MARKER, DyeColor.YELLOW.getFireworkColor(), null, 16, 16, false);
-		addChild(deleteMarkerBookmark).offsetGuiCoords(bookWidth - 10, 33);
+		addChild(deleteMarkerBookmark);
+		offsetSideButton(deleteMarkerBookmark);
 		deleteMarkerBookmark.addListener(button -> {
 			if (state.is(DELETING_MARKER)) {
 				selectedButton = null;
@@ -136,7 +140,8 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 			}
 		});
 		markerVisibilityBookmark = new BookmarkButton(Text.translatable("gui.antique_atlas.hideMarkers"), ICON_HIDE_MARKERS, DyeColor.GREEN.getFireworkColor(), null, 16, 16, false);
-		addChild(markerVisibilityBookmark).offsetGuiCoords(bookWidth - 10, 52);
+		addChild(markerVisibilityBookmark);
+		offsetSideButton(markerVisibilityBookmark);
 		markerVisibilityBookmark.addListener(button -> {
 			selectedButton = null;
 			if (state.is(HIDING_MARKERS)) {
@@ -147,7 +152,8 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 			}
 		});
 		resetScaleBookmark = new TextBookmarkButton(Text.translatable("gui.antique_atlas.resetScale"), Text.of("1c"));
-		addChild(resetScaleBookmark).offsetGuiCoords(bookWidth - 10, 71);
+		addChild(resetScaleBookmark);
+		offsetSideButton(resetScaleBookmark);
 		resetScaleBookmark.addListener(button -> {
 			resetZoom();
 			resetScaleBookmark.setSelected(false);
@@ -728,5 +734,10 @@ public class AtlasScreen extends Component implements AtlasRenderer {
 	@Override
 	public WorldAtlasData worldAtlasData() {
 		return worldAtlasData;
+	}
+
+	public void offsetSideButton(Component component) {
+		component.offsetGuiCoords(bookWidth - 10, sideButtonY);
+		sideButtonY += component.getHeight() + 1;
 	}
 }

--- a/src/main/java/folk/sisby/antique_atlas/gui/BookmarkButton.java
+++ b/src/main/java/folk/sisby/antique_atlas/gui/BookmarkButton.java
@@ -38,7 +38,7 @@ public class BookmarkButton extends ToggleButtonComponent {
 		setSize(WIDTH, HEIGHT);
 	}
 
-	BookmarkButton(Text title, Identifier iconTexture, @Nullable Integer backgroundTint, @Nullable Integer iconTint, int iconWidth, int iconHeight, boolean left) {
+	protected BookmarkButton(Text title, Identifier iconTexture, @Nullable Integer backgroundTint, @Nullable Integer iconTint, int iconWidth, int iconHeight, boolean left) {
 		this(left ? TEXTURE_LEFT : TEXTURE_RIGHT, title, iconTexture, backgroundTint, iconTint, iconWidth, iconHeight, left);
 	}
 


### PR DESCRIPTION
This allows buttons to be added to the right side of the AtlasScreen without knowing exactly where each button is. It allows multiple addons to place a button on the right side without them overlapping when hardcoding their height.
This also makes the BookmarkButton protected as discussed