### PR TITLE
Per-biome tile overrides

### DIFF
--- a/src/main/java/folk/sisby/antique_atlas/TerrainProviderMapped.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainProviderMapped.java
@@ -1,0 +1,7 @@
+package folk.sisby.antique_atlas;
+
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+public record TerrainProviderMapped(TerrainTileProvider provider, @Nullable TileElevation elevation, @Nullable Identifier override) {
+}

--- a/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
@@ -10,16 +10,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public record TerrainTileProvider(Identifier id, Map<TileElevation, List<TileTexture>> textures) {
-	public static final TerrainTileProvider DEFAULT = new TerrainTileProvider(AntiqueAtlas.id("test"), List.of(TileTexture.DEFAULT));
+public record TerrainTileProvider(Identifier id, Map<TileElevation, List<TileTexture>> textures, @Nullable Map<Identifier, List<TileTexture>> overrides) {
+	public static final TerrainTileProvider DEFAULT = new TerrainTileProvider(AntiqueAtlas.id("test"), List.of(TileTexture.DEFAULT), null);
 
 	public TerrainTileProvider(Identifier id, List<TileTexture> textures) {
-		this(id, Arrays.stream(TileElevation.values()).collect(Collectors.toMap(e -> e, e -> textures)));
+		this(id, textures, null);
+	}
+
+	public TerrainTileProvider(Identifier id, List<TileTexture> textures, @Nullable Map<Identifier, List<TileTexture>> overrides) {
+		this(id, Arrays.stream(TileElevation.values()).collect(Collectors.toMap(e -> e, e -> textures)), overrides);
 	}
 
 	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation) {
+		return getTexture(pos, elevation, null);
+	}
+
+	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation, @Nullable Identifier override) {
 		int variation = (int) (MathHelper.hashCode(pos.x, pos.z, pos.x * pos.z) & 0x7FFFFFFF);
-		TileElevation usedElevation = elevation == null ? TileElevation.VALLEY : elevation;
-		return textures.get(usedElevation).get(variation % textures.get(usedElevation).size());
+		if (override != null) {
+			return overrides.get(override).get(variation % overrides.get(id).size());
+		} else {
+			TileElevation usedElevation = elevation == null ? TileElevation.VALLEY : elevation;
+			return textures.get(usedElevation).get(variation % textures.get(usedElevation).size());
+		}
 	}
 }

--- a/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
@@ -21,13 +21,9 @@ public record TerrainTileProvider(Identifier id, Map<TileElevation, List<TileTex
 		this(id, Arrays.stream(TileElevation.values()).collect(Collectors.toMap(e -> e, e -> textures)), overrides);
 	}
 
-	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation) {
-		return getTexture(pos, elevation, null);
-	}
-
-	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation, @Nullable Identifier override) {
+	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation, Identifier override) {
 		int variation = (int) (MathHelper.hashCode(pos.x, pos.z, pos.x * pos.z) & 0x7FFFFFFF);
-		if (override != null) {
+		if (overrides != null && overrides.containsKey(override)) {
 			return overrides.get(override).get(variation % overrides.get(id).size());
 		} else {
 			TileElevation usedElevation = elevation == null ? TileElevation.VALLEY : elevation;

--- a/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTileProvider.java
@@ -13,17 +13,13 @@ import java.util.stream.Collectors;
 public record TerrainTileProvider(Identifier id, Map<TileElevation, List<TileTexture>> textures, @Nullable Map<Identifier, List<TileTexture>> overrides) {
 	public static final TerrainTileProvider DEFAULT = new TerrainTileProvider(AntiqueAtlas.id("test"), List.of(TileTexture.DEFAULT), null);
 
-	public TerrainTileProvider(Identifier id, List<TileTexture> textures) {
-		this(id, textures, null);
-	}
-
 	public TerrainTileProvider(Identifier id, List<TileTexture> textures, @Nullable Map<Identifier, List<TileTexture>> overrides) {
 		this(id, Arrays.stream(TileElevation.values()).collect(Collectors.toMap(e -> e, e -> textures)), overrides);
 	}
 
-	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation, Identifier override) {
+	public TileTexture getTexture(ChunkPos pos, @Nullable TileElevation elevation, @Nullable Identifier override) {
 		int variation = (int) (MathHelper.hashCode(pos.x, pos.z, pos.x * pos.z) & 0x7FFFFFFF);
-		if (overrides != null && overrides.containsKey(override)) {
+		if (override != null && overrides != null && overrides.containsKey(override)) {
 			return overrides.get(override).get(variation % overrides.get(id).size());
 		} else {
 			TileElevation usedElevation = elevation == null ? TileElevation.VALLEY : elevation;

--- a/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
@@ -44,7 +44,6 @@ public class TerrainTiling {
 		FeatureTiles.WATER,
 		FeatureTiles.ICE,
 		FeatureTiles.TILE_RAVINE,
-		FeatureTiles.SWAMP_WATER,
 		FeatureTiles.TILE_LAVA,
 		FeatureTiles.TILE_LAVA_SHORE
 	);
@@ -65,10 +64,6 @@ public class TerrainTiling {
 				return 1;
 			}
 		});
-	}
-
-	public static boolean isSwamp(Registry<Biome> biomeRegistry, Biome biome) {
-		return swampCache.computeIfAbsent(biome, b -> biomeRegistry.getEntry(b).isIn(ConventionalBiomeTags.SWAMP));
 	}
 
 	public static Pair<TerrainTileProvider, TileElevation> frequencyToTexture(int[][] possibleTiles, Registry<Biome> biomeRegistry, IndexedIterable<Biome> biomePalette) {
@@ -124,7 +119,7 @@ public class TerrainTiling {
 			if (checkRavines && height - SEA_LEVEL < -7) {
 				possibleTiles[elevationSize][biomeCount + CUSTOM_TILES.indexOf(FeatureTiles.TILE_RAVINE)] += RAVINE_PRIORITY;
 			} else if (lithograph.waterDepths()[i] > 0) {
-				possibleTiles[elevationSize][biomeCount + CUSTOM_TILES.indexOf(isSwamp(biomeRegistry, biome) ? FeatureTiles.SWAMP_WATER : FeatureTiles.WATER)] += WATER_PRIORITY;
+				possibleTiles[elevationSize][biomeCount + CUSTOM_TILES.indexOf(FeatureTiles.WATER)] += WATER_PRIORITY;
 			} else if (block == Blocks.ICE) {
 				possibleTiles[elevationSize][biomeCount + CUSTOM_TILES.indexOf(FeatureTiles.ICE)] += ICE_PRIORITY;
 			} else if (block == Blocks.LAVA) {

--- a/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
+++ b/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java
@@ -5,10 +5,8 @@ import folk.sisby.surveyor.WorldSummary;
 import folk.sisby.surveyor.terrain.ChunkSummary;
 import folk.sisby.surveyor.terrain.LayerSummary;
 import folk.sisby.surveyor.terrain.WorldTerrain;
-import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.Reference2BooleanArrayMap;
 import it.unimi.dsi.fastutil.objects.Reference2IntArrayMap;
-import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBiomeTags;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.registry.DynamicRegistryManager;
@@ -23,6 +21,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +65,7 @@ public class TerrainTiling {
 		});
 	}
 
-	public static Pair<TerrainTileProvider, TileElevation> frequencyToTexture(int[][] possibleTiles, Registry<Biome> biomeRegistry, IndexedIterable<Biome> biomePalette) {
+	public static TerrainProviderMapped frequencyToTexture(int[][] possibleTiles, Registry<Biome> biomeRegistry, IndexedIterable<Biome> biomePalette) {
 		int elevationOrdinal = -1;
 		int biomeIndex = -1;
 		int bestFrequency = 0;
@@ -81,11 +80,17 @@ public class TerrainTiling {
 		}
 		if (bestFrequency == 0) return null;
 		int customTileIndex = biomeIndex - possibleTiles[0].length + CUSTOM_TILES.size();
-		Identifier providerId = customTileIndex >= 0 ? CUSTOM_TILES.get(customTileIndex) : biomeRegistry.getId(biomePalette.get(biomeIndex));
-		return Pair.of(BiomeTileProviders.getInstance().getTileProvider(providerId), elevationOrdinal == TileElevation.values().length ? null : TileElevation.values()[elevationOrdinal]);
+		TerrainTileProvider biomeProvider = BiomeTileProviders.getInstance().getTileProvider(biomeRegistry.getId(biomePalette.get(biomeIndex)));
+		Identifier providerId;
+		if (customTileIndex >= 0 && biomeProvider.overrides() != null && biomeProvider.overrides().containsKey(CUSTOM_TILES.get(customTileIndex))) {
+			// override for this tile is found
+			providerId = biomeRegistry.getId(biomePalette.get(biomeIndex + Math.max(0, customTileIndex + 1))); // <- HELP! what goes here?
+		} else {
+			providerId = customTileIndex >= 0 ? CUSTOM_TILES.get(customTileIndex) : biomeRegistry.getId(biomePalette.get(biomeIndex));
+		}return new TerrainProviderMapped(BiomeTileProviders.getInstance().getTileProvider(providerId), elevationOrdinal == TileElevation.values().length ? null : TileElevation.values()[elevationOrdinal], customTileIndex >= 0 ? CUSTOM_TILES.get(customTileIndex) : null);
 	}
 
-	public static Pair<TerrainTileProvider, TileElevation> terrainToTile(WorldSummary summary, DynamicRegistryManager manager, ChunkPos pos) {
+	public static TerrainProviderMapped terrainToTile(WorldSummary summary, DynamicRegistryManager manager, ChunkPos pos) {
 		Registry<Biome> biomeRegistry = manager.get(RegistryKeys.BIOME);
 		int defaultTile = CUSTOM_TILES.indexOf(summary.dimension() == World.END ? FeatureTiles.END_VOID : FeatureTiles.EMPTY);
 		boolean checkRavines = summary.dimension() == World.OVERWORLD;
@@ -99,7 +104,7 @@ public class TerrainTiling {
 		@Nullable LayerSummary.Raw lithograph = chunk.toSingleLayer(null, null, topY);
 		IndexedIterable<Biome> biomePalette = terrain.getBiomePalette(pos);
 		IndexedIterable<Block> blockPalette = terrain.getBlockPalette(pos);
-		if (lithograph == null) return Pair.of(BiomeTileProviders.getInstance().getTileProvider(CUSTOM_TILES.get(defaultTile)), null);
+		if (lithograph == null) return new TerrainProviderMapped(BiomeTileProviders.getInstance().getTileProvider(CUSTOM_TILES.get(defaultTile)), null, null);
 
 		int elevationSize = TileElevation.values().length;
 		int elevationCount = elevationSize + 1;
@@ -131,7 +136,7 @@ public class TerrainTiling {
 		return frequencyToTexture(possibleTiles, biomeRegistry, biomePalette);
 	}
 
-	public static Pair<TerrainTileProvider, TileElevation> terrainToTileNether(WorldSummary summary, DynamicRegistryManager manager, ChunkPos pos) {
+	public static TerrainProviderMapped terrainToTileNether(WorldSummary summary, DynamicRegistryManager manager, ChunkPos pos) {
 		Registry<Biome> biomeRegistry = manager.get(RegistryKeys.BIOME);
 		int defaultTile = CUSTOM_TILES.indexOf(FeatureTiles.BEDROCK_ROOF);
 
@@ -154,7 +159,7 @@ public class TerrainTiling {
 		int[][] possibleTiles = new int[elevationCount][baseTileCount];
 
 		if (fullLithograph == null) {
-			return Pair.of(BiomeTileProviders.getInstance().getTileProvider(CUSTOM_TILES.get(defaultTile)), null);
+			return new TerrainProviderMapped(BiomeTileProviders.getInstance().getTileProvider(CUSTOM_TILES.get(defaultTile)), null, null);
 		}
 
 		int SEA_DEPTH = topY - 31;

--- a/src/main/java/folk/sisby/antique_atlas/WorldAtlasData.java
+++ b/src/main/java/folk/sisby/antique_atlas/WorldAtlasData.java
@@ -95,7 +95,7 @@ public class WorldAtlasData {
 			Pair<TerrainTileProvider, TileElevation> tile = summary.dimension() == World.NETHER ? TerrainTiling.terrainToTileNether(summary, manager, pos) : TerrainTiling.terrainToTile(summary, manager, pos);
 			if (tile != null) {
 				tileScope.extendTo(pos.x, pos.z);
-				biomeTiles.put(pos, tile.left().getTexture(pos, tile.right()));
+				biomeTiles.put(pos, tile.left().getTexture(pos, tile.right(), tile.left().id()));
 				debugBiomes.put(pos, tile.left());
 				debugBiomePredicates.put(pos, tile.right() == null ? null : tile.right().getName());
 			}

--- a/src/main/java/folk/sisby/antique_atlas/WorldAtlasData.java
+++ b/src/main/java/folk/sisby/antique_atlas/WorldAtlasData.java
@@ -92,12 +92,12 @@ public class WorldAtlasData {
 			ChunkPos pos = terrainDeque.pollFirst();
 			terrainDequeHash.remove(pos);
 			if (pos == null) break;
-			Pair<TerrainTileProvider, TileElevation> tile = summary.dimension() == World.NETHER ? TerrainTiling.terrainToTileNether(summary, manager, pos) : TerrainTiling.terrainToTile(summary, manager, pos);
+			TerrainProviderMapped tile = summary.dimension() == World.NETHER ? TerrainTiling.terrainToTileNether(summary, manager, pos) : TerrainTiling.terrainToTile(summary, manager, pos);
 			if (tile != null) {
 				tileScope.extendTo(pos.x, pos.z);
-				biomeTiles.put(pos, tile.left().getTexture(pos, tile.right(), tile.left().id()));
-				debugBiomes.put(pos, tile.left());
-				debugBiomePredicates.put(pos, tile.right() == null ? null : tile.right().getName());
+				biomeTiles.put(pos, tile.provider().getTexture(pos, tile.elevation(), tile.override()));
+				debugBiomes.put(pos, tile.provider());
+				debugBiomePredicates.put(pos, tile.elevation() == null ? null : tile.elevation().getName());
 			}
 		}
 		if (!isFinished && terrainDeque.isEmpty()) {

--- a/src/main/java/folk/sisby/antique_atlas/reloader/BiomeTileProviders.java
+++ b/src/main/java/folk/sisby/antique_atlas/reloader/BiomeTileProviders.java
@@ -197,11 +197,25 @@ public class BiomeTileProviders extends JsonDataLoader implements IdentifiableRe
 					providerParents.put(fileId, parentId);
 					continue;
 				}
+				JsonElement overrideJson = fileJson.get("overrides");
+				Map<Identifier, List<TileTexture>> overrides = null;
+				if (overrideJson != null) {
+					JsonObject overrideObject = overrideJson.getAsJsonObject();
+					List<TileTexture> overrideTextures = null;
+					for (String rawId : overrideObject.keySet()) {
+						Identifier id = Identifier.tryParse(rawId);
+						if (overrideTextures == null) throw new IllegalStateException("Invalid id %s in overrides object!".formatted(rawId));
+						overrideTextures = resolveTextureJson(textures, overrideObject.get(rawId));
+						if (overrideTextures == null) throw new IllegalStateException("Malformed object %s in overrides object!".formatted(rawId));
+						overrideTextures.forEach(unusedTextures::remove);
+						overrides.put(id, overrideTextures);
+					}
+				}
 				JsonElement textureJson = fileJson.get("textures");
 				List<TileTexture> defaultTextures = resolveTextureJson(textures, textureJson);
 				if (defaultTextures != null) {
 					defaultTextures.forEach(unusedTextures::remove);
-					tileProviders.put(fileId, new TerrainTileProvider(fileId, defaultTextures));
+					tileProviders.put(fileId, new TerrainTileProvider(fileId, defaultTextures, overrides));
 				} else {
 					JsonObject textureObject = textureJson.getAsJsonObject();
 					Map<TileElevation, List<TileTexture>> textureElevations = new HashMap<>();
@@ -227,7 +241,7 @@ public class BiomeTileProviders extends JsonDataLoader implements IdentifiableRe
 					for (TileElevation elevation : skippedElevations) {
 						textureElevations.put(elevation, elevationTextures);
 					}
-					tileProviders.put(fileId, new TerrainTileProvider(fileId, textureElevations));
+					tileProviders.put(fileId, new TerrainTileProvider(fileId, textureElevations, overrides));
 				}
 			} catch (Exception e) {
 				AntiqueAtlas.LOGGER.error("[Antique Atlas] Error reading biome tile provider {}!", fileId, e);

--- a/src/main/java/folk/sisby/antique_atlas/reloader/BiomeTileProviders.java
+++ b/src/main/java/folk/sisby/antique_atlas/reloader/BiomeTileProviders.java
@@ -198,18 +198,20 @@ public class BiomeTileProviders extends JsonDataLoader implements IdentifiableRe
 					continue;
 				}
 				JsonElement overrideJson = fileJson.get("overrides");
-				Map<Identifier, List<TileTexture>> overrides = null;
+				Map<Identifier, List<TileTexture>> overrides = new HashMap<>();
 				if (overrideJson != null) {
 					JsonObject overrideObject = overrideJson.getAsJsonObject();
 					List<TileTexture> overrideTextures = null;
 					for (String rawId : overrideObject.keySet()) {
-						Identifier id = Identifier.tryParse(rawId);
-						if (overrideTextures == null) throw new IllegalStateException("Invalid id %s in overrides object!".formatted(rawId));
+						Identifier id = AntiqueAtlas.id(rawId);
+						if (id == null) throw new IllegalStateException("Invalid id %s in overrides object!".formatted(rawId));
 						overrideTextures = resolveTextureJson(textures, overrideObject.get(rawId));
 						if (overrideTextures == null) throw new IllegalStateException("Malformed object %s in overrides object!".formatted(rawId));
 						overrideTextures.forEach(unusedTextures::remove);
 						overrides.put(id, overrideTextures);
 					}
+				} else {
+					overrides = null;
 				}
 				JsonElement textureJson = fileJson.get("textures");
 				List<TileTexture> defaultTextures = resolveTextureJson(textures, textureJson);

--- a/src/main/resources/assets/antique_atlas/atlas/biome/feature/swamp_water.json
+++ b/src/main/resources/assets/antique_atlas/atlas/biome/feature/swamp_water.json
@@ -1,3 +1,0 @@
-{
-	"textures": "antique_atlas:biome/wetland/swamp/swamp_water"
-}

--- a/src/main/resources/assets/minecraft/atlas/biome/mangrove_swamp.json
+++ b/src/main/resources/assets/minecraft/atlas/biome/mangrove_swamp.json
@@ -1,3 +1,6 @@
 {
-	"textures": "antique_atlas:biome/wetland/swamp/mangrove/swamp_water_mangrove"
+	"textures": "antique_atlas:biome/wetland/swamp/mangrove/swamp_water_mangrove",
+	"overrides": {
+		"antique_atlas:feature/water": ["antique_atlas:biome/wetland/swamp/swamp_water"]
+	}
 }

--- a/src/main/resources/assets/minecraft/atlas/biome/swamp.json
+++ b/src/main/resources/assets/minecraft/atlas/biome/swamp.json
@@ -14,5 +14,8 @@
 			"antique_atlas:biome/wetland/swamp/swamp_water_grass_oak_swamp_hills_3",
 			"antique_atlas:biome/wetland/swamp/swamp_water_grass_oak_swamp_hills_4"
 		]
+	},
+	"overrides": {
+		"antique_atlas:feature/water": ["antique_atlas:biome/wetland/swamp/swamp_water"]
 	}
 }


### PR DESCRIPTION
Closes #318 (but not #103!)

Almost done, I just can't figure out how the indexes here work:
https://github.com/sisby-folk/antique-atlas/blob/15a6f263f8ee10dddbd680916d7c8b95a1c091d0/src/main/java/folk/sisby/antique_atlas/TerrainTiling.java#L82-L90
At return time, `providerId` should be the custom tile ID if there is a custom tile and there is no override on it on the selected detected biome's provider's overrides map keys, and the biome tile ID otherwise.

Swamp water is migrated over as an example of how the JSON format for this feature works.